### PR TITLE
Change erlang-dependency on rabbitmq to PAS bucket

### DIFF
--- a/rabbitmq361.json
+++ b/rabbitmq361.json
@@ -4,7 +4,7 @@
 	"license" : "https://github.com/rabbitmq/rabbitmq-server/blob/master/LICENSE-MPL-RabbitMQ",
 	"url": "https://www.rabbitmq.com/releases/rabbitmq-server/v3.6.1/rabbitmq-server-windows-3.6.1.zip",
 	"hash": "AFC2E40EB7C00E6ADC6C6FAF7D40879F14DD5E98FAF6B9EC4338C4569110FCFD",
-	"depends" : "erlang",
+	"depends" : "erlang1830",
 	"extract_dir":"rabbitmq_server-3.6.1",
 	"bin": [
 		"sbin\\rabbitmq-server.bat",


### PR DESCRIPTION
For å hindre at installering av `rabbitmq361` installerer `erlang` fra scoop når vår eksplisitte `erlang1830` allerede er installert
